### PR TITLE
Lein 2.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Provides a dependency containing a lein uberjar.  See
 ## Usage
 
 ```clj
-[lein-as-resource "2.1.3"]
+[lein-as-resource "2.5.0"]
 ```
 
 The lein uberjar is provided as "lein-standalone.jar".
 
 ## License
 
-Copyright © 2013 Hugo Duncan
+Copyright © 2013. 2015 Hugo Duncan
 
 Distributed under the Eclipse Public License.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Provides a dependency containing a lein uberjar.  See
 ## Usage
 
 ```clj
-[lein-as-resource "2.5.0"]
+[lein-as-resource "2.7.0"]
 ```
 
 The lein uberjar is provided as "lein-standalone.jar".

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-as-resource "2.1.3"
+(defproject lein-as-resource "2.5.0"
   :description "Provide leiningen as a resource jar on the classpath."
   :url "https://github.com/pallet/lein-as-resource"
   :license {:name "Eclipse Public License"
@@ -8,10 +8,11 @@
   ;; we put the uberjar in classes, which means it will be included
   ;; in the final jar
   :uberjar-name "classes/lein-standalone.jar"
+  :auto-clean false
 
   ;; we build with the lein profile, to pull in lein, but keep it out
   ;; of the project's dependencies.
-  :profiles {:lein {:dependencies [[leiningen "2.1.3"]]}}
+  :profiles {:lein {:dependencies [[leiningen "2.5.0"]]}}
   :aliases {"jar" ["do" "with-profile" "+lein" "uberjar," "jar"]
             "install" ["do" "with-profile" "+lein" "uberjar," "install"]
             "deploy" ["do" "with-profile" "+lein" "uberjar," "deploy"]})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-as-resource "2.5.0"
+(defproject lein-as-resource "2.7.0"
   :description "Provide leiningen as a resource jar on the classpath."
   :url "https://github.com/pallet/lein-as-resource"
   :license {:name "Eclipse Public License"
@@ -12,7 +12,7 @@
 
   ;; we build with the lein profile, to pull in lein, but keep it out
   ;; of the project's dependencies.
-  :profiles {:lein {:dependencies [[leiningen "2.5.0"]]}}
+  :profiles {:lein {:dependencies [[leiningen "2.7.0"]]}}
   :aliases {"jar" ["do" "with-profile" "+lein" "uberjar," "jar"]
             "install" ["do" "with-profile" "+lein" "uberjar," "install"]
             "deploy" ["do" "with-profile" "+lein" "uberjar," "deploy"]})


### PR DESCRIPTION
Update to lein 2.7.0.

There was an issue with alembic and cider 0.12.0+, got an exception `Could not locate cider/inlined_deps/fipp/v0v6v5/fipp/edn__init.class or cider/inlined_deps/fipp/v0v6v5/fipp/edn.clj`. It because cider needs lein 2.5.2+, and alembic includes lein-as-resource 2.5.0.

Therefore, upgrade the lein-as-resource to the latest version of lein (2.7.0 now) can fix the issue.
